### PR TITLE
Bug 777516, change sentry_log.reason to mediumtext

### DIFF
--- a/sql/incremental.sql
+++ b/sql/incremental.sql
@@ -114,3 +114,6 @@ ALTER TABLE `mirror_lmm_lang_exceptions` ADD UNIQUE (
 ALTER TABLE `geoip_regions` ADD COLUMN `fallback_id` integer;
 ALTER TABLE `geoip_regions` ADD CONSTRAINT `fallback_id_refs_id_e6bfe66d` FOREIGN KEY (`fallback_id`) REFERENCES `geoip_regions` (`id`);
 CREATE INDEX `geoip_regions_e28329c2` ON `geoip_regions` (`fallback_id`);
+
+-- more space for sentry logs (bug 777516)
+ALTER TABLE `sentry_log` MODIFY `reason` MEDIUMTEXT;


### PR DESCRIPTION
This is modified by hand based on what Sheeri did at https://bugzilla.mozilla.org/show_bug.cgi?id=716440#c37. Is it correct to leave bouncer/php/cfg/mirror.sql as is, and let the migration code change the data type ?
