### PR TITLE
Bug 809229, show ssl_only in product listing UI

### DIFF
--- a/apps/mirror/admin.py
+++ b/apps/mirror/admin.py
@@ -34,8 +34,8 @@ class ProductLanguageInline(admin.TabularInline):
 
 
 class ProductAdmin(admin.ModelAdmin):
-    list_display = ('name', 'priority', 'count', 'active', 'checknow')
-    list_filter = ('active', 'checknow')
+    list_display = ('name', 'priority', 'count', 'active', 'checknow', 'ssl_only')
+    list_filter = ('active', 'checknow', 'ssl_only')
     ordering = ('name',)
     actions = ('mark_for_checknow',)
     inlines = [ProductLanguageInline]


### PR DESCRIPTION
Enhances the UI by adding a filter on the ssl_only boolean, and shows that in the product list. Both apply to the admin/mirror/product page.
