### PR TITLE
do not require ssh for submodules, for jenkins

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 
 [submodule "vendor"]
 	path = vendor
-	url = git@github.com:mozilla/tuxedo-lib.git
+	url = git://github.com:mozilla/tuxedo-lib.git


### PR DESCRIPTION
Jenkins is trying to clone submodules and it is requiring a key, because it's using the SSH and not the anonymous git URL.
