### PR TITLE
Longer max-age

### DIFF
--- a/bouncer/php/functions.php
+++ b/bouncer/php/functions.php
@@ -6,7 +6,7 @@
 function show_no_cache_headers() {
     //header('Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0, private');
     //header('Pragma: no-cache');
-    header('Cache-Control: max-age=15');
+    header('Cache-Control: max-age=60');
 }
 
 /**


### PR DESCRIPTION
There's no longer any reason why this can't be cached for a longer interval. This change increases our LB cache hit rate from about 90% to 93-94%, which is a 30-40% reduction in load on the backend servers.

Still don't want to go _too_ high, as it will start to elongate the time between when a release is created and when it becomes available.
